### PR TITLE
Delegate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ var peer = new SimplePeer({
   initiator: true,
   wrtc: wrtc
 })
+
+// listen for errors
+wrtc.on('error', function (err, source) {
+  console.error(err)
+})
 ```
 
 ### Methods
@@ -53,6 +58,11 @@ Closes the Electron process and releases its resources. You may not need to do t
 #### `wrtc.electronDaemon`
 
 A handle to the [`electron-eval`](https://github.com/mappum/electron-eval) daemon that this module uses to talk to the Electron process.
+
+### Events
+
+#### - `error`
+Emitted by `RTCPeerConnection` or `RTCDataChannel` when `daemon.eval()` evaluates code that throws an internal error.
 
 ### Running on a headless server
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var electron = require('electron-eval')
 
-module.exports = function (cb) {
+module.exports = function () {
   var daemon = electron()
   return {
     electronDaemon: daemon,
-    RTCPeerConnection: require('./src/RTCPeerConnection.js')(daemon, cb),
+    RTCPeerConnection: require('./src/RTCPeerConnection.js')(daemon),
     RTCSessionDescription: require('./src/RTCSessionDescription.js'),
     RTCIceCandidate: require('./src/RTCIceCandidate.js'),
     RTCDataChannel: require('./src/RTCDataChannel.js')

--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
+var EventEmitter = require('events').EventEmitter
 var electron = require('electron-eval')
 
 module.exports = function () {
   var daemon = electron()
-  return {
+  var wrtc = new EventEmitter()
+
+  return Object.assign(wrtc, {
     electronDaemon: daemon,
-    RTCPeerConnection: require('./src/RTCPeerConnection.js')(daemon),
+    RTCPeerConnection: require('./src/RTCPeerConnection.js')(daemon, wrtc),
     RTCSessionDescription: require('./src/RTCSessionDescription.js'),
     RTCIceCandidate: require('./src/RTCIceCandidate.js'),
     RTCDataChannel: require('./src/RTCDataChannel.js')
-  }
+  })
 }

--- a/src/RTCDataChannel.js
+++ b/src/RTCDataChannel.js
@@ -3,7 +3,7 @@
 var EventEmitter = require('events').EventEmitter
 var debug = require('debug')('RTCDC')
 
-module.exports = function (daemon) {
+module.exports = function (daemon, wrtc) {
   daemon.eval(`
     window.arrayBufferToBase64 = function (buffer) {
       var binary = ''
@@ -53,7 +53,7 @@ module.exports = function (daemon) {
       this.reliable = typeof opts.reliable === 'boolean' ? opts.reliable : true
 
       this.on('error', (err) => {
-        if (/daemon/i.test(err.message)) daemon.emit('error', err)
+        if (/daemon/i.test(err.message)) wrtc.emit('error', err, this)
       })
 
       daemon.eval(`

--- a/src/RTCDataChannel.js
+++ b/src/RTCDataChannel.js
@@ -51,11 +51,7 @@ module.exports = function (daemon, wrtc) {
       this.maxRetransmits = null
       this.negotiated = false
       this.reliable = typeof opts.reliable === 'boolean' ? opts.reliable : true
-
-      this.on('error', (err) => {
-        if (/daemon/i.test(err.message)) wrtc.emit('error', err, this)
-      })
-
+      this.on('error', (err) => wrtc.emit('error', err, this))
       daemon.eval(`
         var pc = conns[${JSON.stringify(pcId)}]
         var dc = pc.createDataChannel(

--- a/src/RTCDataChannel.js
+++ b/src/RTCDataChannel.js
@@ -52,6 +52,10 @@ module.exports = function (daemon) {
       this.negotiated = false
       this.reliable = typeof opts.reliable === 'boolean' ? opts.reliable : true
 
+      this.on('error', (err) => {
+        if (/daemon/i.test(err.message)) daemon.emit('error', err)
+      })
+
       daemon.eval(`
         var pc = conns[${JSON.stringify(pcId)}]
         var dc = pc.createDataChannel(
@@ -59,7 +63,7 @@ module.exports = function (daemon) {
         pc.dataChannels[dc.id] = dc
         dc.id
       `, (err, id) => {
-        if (err) this.emit('error', err)
+        if (err) return this.emit('error', err)
         this.id = this.stream = id
         this._registerListeners()
         this.emit('init')
@@ -113,7 +117,7 @@ module.exports = function (daemon) {
         }
         if (dc.readyState === 'open') dc.onopen()
       `, cb || ((err) => {
-        if (err) return this.emit('error', err)
+        if (err) this.emit('error', err)
       }))
     }
 

--- a/src/RTCPeerConnection.js
+++ b/src/RTCPeerConnection.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var EventEmitter = require('events').EventEmitter
 var hat = require('hat')
 var debug = require('debug')('RTCPC')
 
@@ -12,9 +11,8 @@ module.exports = function (daemon) {
     if (err) daemon.emit('error', err)
   })
 
-  return class RTCPeerConnection extends EventEmitter {
+  return class RTCPeerConnection {
     constructor (opts) {
-      super()
       this._id = (i++).toString(36)
       this._dataChannels = new Map()
       this.iceConnectionState = 'new'
@@ -105,7 +103,7 @@ module.exports = function (daemon) {
           }
         })()
       `, (err) => {
-        if (err) this.emit('error', err)
+        if (err) daemon.emit('error', err)
       })
     }
 
@@ -260,7 +258,7 @@ module.exports = function (daemon) {
           pc.${name}(${args || ''})
         })()
       `, (err) => {
-        if (err) this.emit('error', err)
+        if (err) daemon.emit('error', err)
       })
       return promise
     }

--- a/src/RTCPeerConnection.js
+++ b/src/RTCPeerConnection.js
@@ -3,12 +3,12 @@
 var hat = require('hat')
 var debug = require('debug')('RTCPC')
 
-module.exports = function (daemon) {
-  var RTCDataChannel = require('./RTCDataChannel.js')(daemon)
+module.exports = function (daemon, wrtc) {
+  var RTCDataChannel = require('./RTCDataChannel.js')(daemon, wrtc)
 
   var i = 0
   daemon.eval('window.conns = {}', (err) => {
-    if (err) daemon.emit('error', err)
+    if (err) wrtc.emit('error', err)
   })
 
   return class RTCPeerConnection {
@@ -103,7 +103,7 @@ module.exports = function (daemon) {
           }
         })()
       `, (err) => {
-        if (err) daemon.emit('error', err)
+        if (err) wrtc.emit('error', err, this)
       })
     }
 
@@ -258,7 +258,7 @@ module.exports = function (daemon) {
           pc.${name}(${args || ''})
         })()
       `, (err) => {
-        if (err) daemon.emit('error', err)
+        if (err) wrtc.emit('error', err, this)
       })
       return promise
     }


### PR DESCRIPTION
As the `electron-eval` daemon [emits proper errors](https://github.com/mappum/electron-eval/blob/master/index.js#L68) for ongoing calls after its closing, a listener for the error event should be provided to handle it. Since the regular [RTCPeerConnection](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection) isn't specified as an emitter, its probably best to delegate these errors to the daemon (which is public available through the `electronDaemon` export).

Not sure why travis has a timeout - locally the tests work:
![electron-webrtc-test](https://cloud.githubusercontent.com/assets/1060490/13779820/39698264-eabd-11e5-9d3c-45c9529eee09.png)
