### PR TITLE
Add optional opts param, updated documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ addons:
       - xvfb
 
 install:
-  - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+  - export HEADLESS=true
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ addons:
       - xvfb
 
 install:
-  - export HEADLESS=true
+  - export HEADLESS=1
+  - echo $HEADLESS
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ addons:
       - xvfb
 
 install:
-  - export HEADLESS=1
-  - echo $HEADLESS
+  - export DISPLAY=':99:0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
       - xvfb
 
 install:
-  - export DISPLAY=':99:0'
+  - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ wrtc.on('error', function (err, source) {
 
 ### Methods
 
-#### `var wrtc = require('electron-webrtc')()`
+#### `var wrtc = require('electron-webrtc')([opts])`
 
 Calling the function exported by this module will create a new hidden Electron process. It is recommended to only create one, since Electron uses a lot of resources.
+
+An optional `opts` object may contain specific options (including headless mode). See [`electron-eval`](https://github.com/nlocnila/electron-eval/blob/master/README.md#var-daemon--electronevalopts)
 
 The object returned by this function has the same API as the [`node-webrtc`](https://github.com/js-platform/node-webrtc) package.
 
@@ -78,10 +80,14 @@ First, install `xvfb`:
 sudo apt-get install xvfb
 ```
 
-Now start it up:
+Create the `HEADLESS` env variable:
 ```sh
-export DISPLAY='0:99'
-Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+export HEADLESS=true
+```
+
+Or if you want to do it programmatically, initialize a new instance and pass in `headless` as a key as demonstrated: 
+```js
+var wrtc = require('electron-webrtc')({ headless: true })
 ```
 
 Now you may run your WebRTC code with `electron-webrtc` :)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ wrtc.on('error', function (err, source) {
 
 Calling the function exported by this module will create a new hidden Electron process. It is recommended to only create one, since Electron uses a lot of resources.
 
-An optional `opts` object may contain specific options (including headless mode). See [`electron-eval`](https://github.com/nlocnila/electron-eval/blob/master/README.md#var-daemon--electronevalopts)
+An optional `opts` object may contain specific options (including headless mode). See [`electron-eval`](https://github.com/mappum/electron-eval#var-daemon--electronevalopts)
 
 The object returned by this function has the same API as the [`node-webrtc`](https://github.com/js-platform/node-webrtc) package.
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var EventEmitter = require('events').EventEmitter
 var electron = require('electron-eval')
 
-module.exports = function () {
-  var daemon = electron()
+module.exports = function (opts) {
+  var daemon = electron(opts)
   var wrtc = new EventEmitter()
 
   return Object.assign(wrtc, {


### PR DESCRIPTION
This PR adds an optional `opts` parameter in response to https://github.com/mappum/electron-eval/commit/9f1651a4d17eccaa887edd085f33e8e17f8613d3. This also includes updated documentation and travis configuration. Should pass tests on 0.5.0.