### PR TITLE
Queuing messages received before `_registerListeners`

### DIFF
--- a/src/RTCPeerConnection.js
+++ b/src/RTCPeerConnection.js
@@ -38,6 +38,11 @@ module.exports = function (daemon, wrtc) {
               if (typeof e.channel[key] === 'function' || e.channel[key] == null) continue
               channel[key] = e.channel[key]
             }
+            // Queues messages that have been recieved before the message listener has been added
+            e.channel.msgQueue = []
+            e.channel.onmessage = function (eMsg) {
+              e.channel.msgQueue.push(eMsg)
+            }
             send(id, {
               type: 'datachannel',
               channel: channel


### PR DESCRIPTION
It is possible for RTCDataChannels to receive messages after the
`datachannel` event, but before `_registerListeners` is called. In
this scenerio, those messages are dropped since no message listener
has been set.

To mitigate this, a temporary message listener is set during the
`datachannel` event handling that pushes messages onto a queue
when they are received. When `_registerListeners` is called,
the temporary listener is replaced with the original and the
queue is processed.