### PR TITLE
Add Ubuntu zesty dependencies for electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ First, install `Xvfb`:
 apt-get install xvfb # Ubuntu/Debian
 yum install xorg-x11-server-Xvfb # CentOS
 ```
+> **Note**: On Ubuntu 17.04 Zesty, you also need the following:
+> ```sh
+> apt install libxtst6 libxss1 libgtk2.0 libgconf2-4 libnss3 libasound2
+> ```
+
 
 Create the `HEADLESS` env variable:
 ```sh


### PR DESCRIPTION
Hi, 

I installed webtorrent-hybrid on a Ubuntu 17.04 Zesty server (headless) . 
I needed to install the dependencies in the commit to make it work.